### PR TITLE
Recognize PostDeref

### DIFF
--- a/lib/Perl/MinimumVersion/Fast.pm
+++ b/lib/Perl/MinimumVersion/Fast.pm
@@ -11,6 +11,7 @@ use List::Util qw(max);
 our $VERSION = "0.15";
 
 my $MIN_VERSION   = version->new('5.008');
+my $VERSION_5_020 = version->new('5.020');
 my $VERSION_5_018 = version->new('5.018');
 my $VERSION_5_016 = version->new('5.016');
 my $VERSION_5_014 = version->new('5.014');
@@ -190,6 +191,8 @@ sub _build_minimum_syntax_version {
                     }
                 }
             }
+        } elsif ($token->{name} eq 'PostDeref' || $token->{name} eq 'PostDerefStar') {
+			$test->("postfix dereference" => $VERSION_5_020);
         }
     }
     return $syntax_version;


### PR DESCRIPTION
I just sent a pull request for Compiler::Lexer
which will produce these names. When that module
is updated, I'll grab the version number and 
adjust the required version.