### PR TITLE
Implement perlver-fast [-v] -e expr

### DIFF
--- a/script/perlver-fast
+++ b/script/perlver-fast
@@ -1,19 +1,36 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
+use Getopt::Long qw(:config bundling passthrough);
 use Perl::MinimumVersion::Fast;
 
+GetOptions(
+    "e:s" => \my $expr,
+    "v"   => \my $verbose,
+) or die "usage: $0 [file | -e expr]\n";
+
 if (@ARGV) {
-    for my $file (@ARGV) {
-        my $v = Perl::MinimumVersion::Fast->new($file);
-        printf "%s: %s\n", $file, $v->minimum_version;
-    }
-} else {
-    my $src = join("", <>);
-    my $v = Perl::MinimumVersion::Fast->new(\$src);
-    printf "STDIN: %s\n", $v->minimum_version;
+    report($_, $_) for @ARGV;
+}
+elsif ($expr) {
+    report("-e", \$expr);
+}
+else {
+    my $src = do { local $/; <> };
+    report("STDIN", \$src);
 }
 
+sub report {
+    my($in, $src) = @_;
+    my $v = Perl::MinimumVersion::Fast->new($src);
+    printf "%s: %s / %s\n", $in, $v->minimum_version, $v->minimum_syntax_version;
+    $verbose or return;
+    my @markers = $v->version_markers;
+    while (@markers) {
+        my($pv, $m) = splice @markers, 0, 2;
+        printf "%-10s %s\n", $pv, $_ for @$m;
+    }
+}
 __END__
 
 =head1 NAME
@@ -22,14 +39,28 @@ perlver-fast - Minimum perl version detector
 
 =head1 SYNOPSIS
 
+reports minimum version and minimum syntax version. Adding C<-c> tries to
+add detailed information.
+
 Analyze from file list
 
     $ perlver-fast lib/Acme/Kensiro.pm t/00.load.t
-    lib/Acme/Kensiro.pm: 5.008001
-    t/00.load.t: 5.006
+    lib/Acme/Kensiro.pm: 5.008001 / 5.006
+    t/00.load.t: 5.006 / 5.006
 
 Analyze from STDIN
 
     $ perlver-fast < lib/Acme/Kensiro.pm
-    STDIN: 5.008001
+    STDIN: 5.008001 / 5.006
 
+Analyze from expression
+
+    $ perlver-fast -e '$a //= 42'
+    -e: 5.010 / 5.010
+
+    $ perlver-fast -v -e '$a //= 42'
+    -e: 5.010 / 5.010
+    5.010      //= operator
+
+    $ perlver-fast -e 'use 5.24.1; $a //= 42'
+    -e: 5.24 / 5.010


### PR DESCRIPTION
$ perlver-fast -e 'use 5.24.1; $a //= 42'
-e: 5.24 / 5.010

I note however that some other features are not (yet) detected. To name just a few

• -e -s -r    (5.010)
• s/\K//      (5.010)
• s///r       (5.014)
• \N{NULL}    (5.016) - whithout "use charnames"
• \p{Unicode} (5.020)
• \b{sb}      (5.022}
• s///n       (5.022)
• \b{lb}      (5.024)
• s///xx      (5.026)
• a < b < c   (5.032)

$ perl -wE '$a = "42"; -e -s -r $a; $b = $a =~ s/x/y/rn; $a =~ s/\b{lb}1\K23\b{sb}/0/xx; $a =~ m/\p{Unicode}/ && 1 < $a < 4 and say "\N{NULL}";' $ perlver-fast -v -e '$a = "42"; -e -s -r $a; $b = $a =~ s/x/y/rn; $a =~ s/\b{lb}1\K23\b{sb}/0/xx; $a =~ m/\p{Unicode}/ && 1 < $a < 4 and say "\N{NULL}";' -e: 5.006 / 5.006

To compare with the non ::Fast version

$ perlver -e '$a = "42"; -e -s -r $a; $b = $a =~ s/x/y/rn; $a =~ s/\b{lb}1\K23\b{sb}/0/xx; $a =~ m/\p{Unicode}/ && 1 < $a < 4 and say "\N{NULL}";'

   -----------------------------------------------
 | file            | explicit | syntax  | external |
 | ----------------------------------------------- |
 | /tmp/PVH11GE.pl | ~        | v5.25.9 | n/a      |
 | ----------------------------------------------- |
 | Minimum explicit version : ~                    |
 | Minimum syntax version   : v5.25.9              |
 | Minimum version of perl  : v5.25.9              |
   -----------------------------------------------