### PR TITLE
suppress "Use of uninitialized value in null operation" warning

### DIFF
--- a/lib/Perl/MinimumVersion/Fast.pm
+++ b/lib/Perl/MinimumVersion/Fast.pm
@@ -210,7 +210,7 @@ sub _build_minimum_syntax_version {
 
 sub minimum_version {
     my $self = shift;
-    return $self->{minimum_explicit_version} > $self->{minimum_syntax_version}
+    return defined $self->{minimum_explicit_version} && ($self->{minimum_explicit_version} > $self->{minimum_syntax_version})
         ? $self->{minimum_explicit_version}
         : $self->{minimum_syntax_version};
 }


### PR DESCRIPTION
On perl 5.14.4 with "version" module 0.88, the following script emits "Use of uninitialized value in null operation" warning:

```perl
use strict;
use warnings;
use version;

print undef > version->new("5.006") ? 1 : 0;
```
```
❯ perl test.pl
Use of uninitialized value in null operation at b.pl line 5.
0
```
---

The same thing is happening on Perl-MinimumVersion-Fast + version module 0.88 as well:
```perl
use strict;
use warnings;
use Perl::MinimumVersion::Fast;

my $p = Perl::MinimumVersion::Fast->new(\"");
print $p->minimum_version, "\n";
```
```
❯ perl test.pl
Use of uninitialized value in null operation at /Users/skaji/env/plenv/versions/5.14.4/lib/perl5/site_perl/5.14.4/Perl/MinimumVersion/Fast.pm line 213.
5.006
```

This PR suppresses "Use of uninitialized value in null operation" warning.